### PR TITLE
changed removeAll & destory to clear the namespace

### DIFF
--- a/nibelu-ng.js
+++ b/nibelu-ng.js
@@ -53,11 +53,11 @@
         };
 
         this.removeAll = function () {
-          cache.clear();
+          cache.clearNamespace();
         };
 
         this.destroy = function () {
-          cache.clear();
+          cache.clearNamespace();
         };
 
         this.info = function () {


### PR DESCRIPTION
Based completely off of https://github.com/rangle/nibelung/pull/26 

I'm assuming a Hoard shouldn't be able to clear / remove / destroy records that don't belong to their namespace. 

@SethDavenport 